### PR TITLE
Reduced size DHCP client (address, socket allocation changes)

### DIFF
--- a/include/socket.h
+++ b/include/socket.h
@@ -22,25 +22,26 @@
 #define SEND 0x20
 #define RECV 0x40
 
-// UDP socket controls
+// Socket toggle commands
+#define ON 1
+#define OFF 0
+
+// UDP/MACRAW socket controls
 #define SEND_MAC 0x21
 
 // Socket modes for the Sn_MR register
 #define TCP_MODE 0x01
-#define UDP_MODE 0x02
+// 4 for broadcast blocking
+#define UDP_MODE 0x42
 // 8 to set the "only receive broadcasts and addresses packets"
 #define MACRAW_MODE 0x84
 
 // Macros for things too small to be a function yet too weird to read
 #define SOCKETMASK(sockno) \
     (sockno << 5)
-#define EMBEDSOCKET(base_addr, sockno) \
-    ((base_addr & 0xFFFFFF1F) | (sockno << 5))
-#define EMBEDADDRESS(base_addr, new_addr) \
-    ((base_addr & 0xFF0000FF) | (((uint32_t)new_addr) << 8))
 
 /* Holds data related to a single socket's operations */
-typedef struct { 
+typedef struct {
     // 0 to 8
     uint8_t sockno;
     // Updated with socket_get_status
@@ -49,13 +50,20 @@ typedef struct {
     uint8_t mode;
     // The W5500 socket interrupt mask, set with socket_initialise
     uint8_t interrupts;
-    // 
+    //
     uint16_t portno;
-    /* The TX write pointer only gets incremented with SEND operations, so we 
+    /* The TX write pointer only gets incremented with SEND operations, so we
     need to track it manually for compound write operations */
     uint16_t tx_pointer;
 } Socket;
 
+// Global address manipulation
+#define embed_socket(sockno) \
+    wizchip_address[2] = (wizchip_address[2] & 0x1F) | (sockno << 5)
+#define set_half_address(byte_two) \
+    wizchip_address[1] = byte_two
+void embed_pointer(uint16_t pointer);
+void set_address(uint8_t byte_one, uint8_t byte_two, uint8_t block);
 
 /* Attaches port number, interrupt mask and mode of operation to socket */
 void socket_initialise(Socket *socket, uint8_t mode, uint16_t portno, uint8_t interrupt_mask);
@@ -65,8 +73,10 @@ void socket_open(Socket *socket);
 void socket_close(const Socket *socket);
 /* Reads the socket's status register into the socket struct */
 void socket_get_status(Socket *socket);
-/*  Toggles a socket's interrupts on or off based on the socket's interrupt mask. 
+/*  Toggles a socket's interrupts on or off based on the socket's interrupt mask.
     Will always include a CON_INT for TCP sockets for pointer tracking purposes, even if not requested by user. */
 void socket_toggle_interrupts(const Socket *socket, bool set_on);
+/*  */
+void socket_update_read_pointer(const Socket *socket, uint16_t read_pointer);
 /* Updates the socket's TX write pointer register and commands the W5500 to transmit the contents of socket TX buffer. */
-void socket_send_message(Socket *socket);
+void socket_send_message(const Socket *socket);

--- a/include/spi.h
+++ b/include/spi.h
@@ -1,8 +1,10 @@
-/* 
-    Module for bit-banged SPI communication between a W5500 and AVR ATtiny85 (or ATmega328P) 
+/*
+    Module for bit-banged SPI communication between a W5500 and AVR ATtiny85 (or ATmega328P)
 */
 
 #pragma once
+
+//#define DEBUG
 
 #include <avr/io.h>
 #include <avr/pgmspace.h>
@@ -11,10 +13,10 @@
 
 // Device-specific pin assignments
 #if defined(__AVR_ATtiny85__)
-    // External interrupt    
+    // External interrupt
     #define INT_MODE MCUCR
     #define INT_ENABLE GIMSK
-    // SPI clock 
+    // SPI clock
     #define CLK PB1
     // SPI chip select
     #define SEL PB4
@@ -28,7 +30,7 @@
 #elif defined(__AVR_ATmega328P__)
     #define INT_MODE EICRA
     #define INT_ENABLE EIMSK
-    // SPI clock 
+    // SPI clock
     #define CLK PB0
     // SPI chip select
     #define SEL PB1
@@ -39,13 +41,13 @@
     // W5500 interrupt signal
     #define INTR PD2
     #define INTREG DDRD
-#else 
+#else
     #error "Not a supported microcontroller"
     // These are only here to stop the red squiggly lines from undefined macros
-    // External interrupt    
+    // External interrupt
     #define INT_MODE MCUCR
     #define INT_ENABLE GIMSK
-    // SPI clock 
+    // SPI clock
     #define CLK PB1
     // SPI chip select
     #define SEL PB4
@@ -63,7 +65,7 @@
 #define ENABLEINT0 (INT_ENABLE |= (1 << INT0))
 #define DISABLEINT0 (INT_ENABLE &= (INT_ENABLE & ~(1 << INT0)))
 
-#define MIN(a, b) ((a < b) ? a : b)
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 /* Dark arts below, grandparental advisory required */
 #define EVAL(...) EVAL8(__VA_ARGS__)
@@ -71,7 +73,7 @@
 #define EVAL2(...) EVAL1(EVAL1(__VA_ARGS__))
 #define EVAL4(...) EVAL2(EVAL2(__VA_ARGS__))
 #define EVAL8(...) EVAL4(EVAL4(__VA_ARGS__))
-#define EMPTY() 
+#define EMPTY()
 #define DEFER(x) x EMPTY()
 #define LOOP(list, i, element, args...) \
     list[i] = element; __VA_OPT__(DEFER(_LOOP)()(list, (i + 1), args))
@@ -79,23 +81,23 @@
 #define ASSIGN(list, i, element, args...) \
     EVAL(LOOP(list, i, element, args))
 
-uint8_t do_arrays_differ(uint8_t *array_1, uint8_t *array_2, uint8_t array_len);
+extern uint8_t wizchip_address[3];
 
 /*  Reads a 2-byte register value repeatedly until the value matches on two consecutive reads.
-    As a 2-byte value has to be read in two pieces, there is a possibility of the value changing mid-read. 
+    As a 2-byte value has to be read in two pieces, there is a possibility of the value changing mid-read.
     Returns the read value. */
-uint16_t get_2_byte(uint32_t addr);
+uint16_t get_2_byte();
 /* Initializes the pins needed for SPI transmissions */
 void spi_init();
 
-/*  Reads data from a given address into to given buffer. 
+/*  Reads data from a given address into to given buffer.
     Returns 0 on full read, difference between buffer length and read length if buffer space is insufficient to hold the whole message. */
-void read(uint32_t addr, uint8_t *buffer, uint8_t buffer_len, uint8_t read_len);
-void read_reversed(uint32_t addr, uint8_t *buffer, uint8_t buffer_len, uint8_t read_len);
+void read(uint8_t *buffer, uint8_t buffer_len, uint8_t read_len);
+void read_reversed(uint8_t *buffer, uint8_t buffer_len, uint8_t read_len);
 
 /* Writes an array to the W5500's registers. */
-void write(uint32_t addr, uint16_t data_len, const uint8_t *data);
+void write(uint16_t data_len, const uint8_t *data);
 /* Writes an array stored in progmem to the W5500's registers. */
-void write_P(uint32_t addr, uint16_t data_len, const uint8_t *data);
+void write_P(uint16_t data_len, const uint8_t *data);
 /* Writes a single byte repeatedly to the W5500's registers. */
-void write_singular(uint32_t addr, uint16_t data_len, uint8_t data);
+void write_singular(uint16_t data_len, uint8_t data);

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -23,22 +23,23 @@
 #define OP_PROGMEM 0x01
 #define OP_HOLDBACK 0x02
 
+extern Socket TCP_Socket;
 
 /* Basic setup to get the socket ready for operation. */
-void tcp_socket_initialise(Socket *socket, uint16_t portno, uint8_t interrupts);
+void tcp_socket_initialise(uint16_t portno, uint8_t interrupts);
 /*  Puts the socket into TCP listen mode. 
     If the socket setup doesn't proceed as expected, returns the status code of the socket. */ 
-uint8_t tcp_listen(Socket *socket);
+uint8_t tcp_listen();
 /*  Writes a message to the socket's TX buffer and sends in the "send" command.
     Operands: 
     - OP_PROGMEM if you're sending in a pointer to an array in program memory rather than a normal array 
     - OP_HOLDBACK if you want to delay sending the message and write more into the buffer */
-uint8_t tcp_send(Socket *socket, uint16_t message_len, const char *message, uint8_t operands);
+uint8_t tcp_send(uint16_t message_len, const char *message, uint8_t operands);
 /*  Reads the socket's RX buffer into a given buffer
     - As the only goal for our server is to get the path from a message, the message is 
     marked as entirely received even when only a small amount is in fact read */
-void tcp_read_received(const Socket *socket, uint8_t *buffer, uint8_t buffer_len);
+void tcp_read_received(uint8_t *buffer, uint8_t buffer_len);
 /* Sends a disconnect command to the socket, which will start a connection close process. */
-void tcp_disconnect(const Socket *socket);
+void tcp_disconnect();
 /* Closes the socket. */
-void tcp_close(const Socket *socket);
+void tcp_close();

--- a/include/w5500.h
+++ b/include/w5500.h
@@ -55,7 +55,7 @@
 /* Device structure */
 typedef struct {
     // Nice bits of data about what sockets are in use
-    Socket sockets[SOCKETNO];
+    Socket *sockets[SOCKETNO];
     // A list of interrupts that have arrived from W5500
     volatile uint8_t interrupt_list[INTERRUPT_LIST_SIZE];
     volatile uint8_t interrupt_list_index;

--- a/include/w5500_addresses.h
+++ b/include/w5500_addresses.h
@@ -1,100 +1,96 @@
 #pragma once
 
+
+#define COMMON_BLOCK 0x00
+#define SOCKET_BLOCK 0x08
+// Socket TX buffer block address
+#define S_TX_BUF_BLOCK 0x10
+// Socket RX buffer block address
+#define S_RX_BUF_BLOCK 0x18
+
 /* Addresses from the common register block, first byte is irrelevant, only the last three matter
 (bytes 1 and 2 are the address, last gets used as basis for a control frame) */
 // Common block - Mode register
-#define MR 0x00000000ul
+#define MR_B 0x00
+#define MR 0x00, 0x00, COMMON_BLOCK
 // Common block - Gateway address IP register
-#define GAR 0x00000100ul
+#define GAR_B 0x01
+#define GAR 0x00, 0x01, COMMON_BLOCK
 // Common block - Subnet mask register
-#define SUBR 0x00000500ul 
+#define SUBR_B 0x05
+#define SUBR 0x00, 0x05, COMMON_BLOCK
 // Common block - Source hardware address register
-#define SHAR 0x00000900ul 
+#define SHAR_B 0x09
+#define SHAR 0x00, 0x09, COMMON_BLOCK
 // Common block - Source IP address
-#define SIPR 0x00000F00ul
+#define SIPR_B 0x0F
+#define SIPR 0x00, 0x0F, COMMON_BLOCK
 // Common block - Interrupt register
-#define IR 0x00001500ul
+#define IR_B 0x15
+#define IR 0x00, 0x15, COMMON_BLOCK
 // Common block - Interrupt mask register
-#define IMR 0x00001600ul
+#define IMR_B 0x16
+#define IMR 0x00, 0x16, COMMON_BLOCK
 // Common block - Socket interrupt register
-#define SIR 0x00001700ul
+#define SIR_B 0x17
+#define SIR 0x00, 0x17, COMMON_BLOCK
 // Common block - Socket interrupt mask register
-#define SIMR 0x00001800ul
+#define SIMR_B 0x18
+#define SIMR 0x00, 0x18, COMMON_BLOCK
 // Common block - PHY configuration register
-#define PHYCFGR 0x00002E00ul
+#define PHYCFGR_B 0x2E
+#define PHYCFGR 0x00, 0x2E, COMMON_BLOCK
 // Common block - Chip version register
-#define VERSIONR 0x00003900ul
-
-// Number of bytes in the registers above 
-#define MR_LEN 1
-#define GAR_LEN 4
-#define SUBR_LEN 4
-#define SHAR_LEN 6
-#define SIPR_LEN 4
-#define IR_LEN 1
-#define IMR_LEN 1
-#define SIR_LEN 1
-#define SIMR_LEN 1
-#define PHYCFGR_LEN 1
-#define VERSIONR_LEN 1
+#define VERSIONR_B 0x39
+#define VERSIONR 0x00, 0x39, COMMON_BLOCK
 
 /* Base addresses for sockets' registers (socket-no-based adjustment done later) */
-// Socket's personal data
+// Sockets' personal data
 // Socket register block - Mode register
-#define S_MR 0x00000008ul
+#define S_MR_B 0x00
+#define S_MR 0x00, 0x00, SOCKET_BLOCK
 // Socket register block - Command register
-#define S_CR 0x00000108ul
+#define S_CR_B 0x01
+#define S_CR 0x00, 0x01, SOCKET_BLOCK
 // Socket register block - Interrupt register
-#define S_IR 0x00000208ul
+#define S_IR_B 0x02
+#define S_IR 0x00, 0x02, SOCKET_BLOCK
 // Socket register block - Status register
-#define S_SR 0x00000308ul
+#define S_SR_B 0x03
+#define S_SR 0x00, 0x03, SOCKET_BLOCK
 // Socket register block - Source port register
-#define S_PORT 0x00000408ul 
+#define S_PORT_B 0x04
+#define S_PORT 0x00, 0x04, SOCKET_BLOCK 
 
 // Counterparty data
 // Socket register block - Destination hardware address register
-#define S_DHAR 0x00000608ul
+#define S_DHAR_B 0x06
+#define S_DHAR 0x00, 0x06, SOCKET_BLOCK
 // Socket register block - Destination IP address register
-#define S_DIPR 0x00000C08ul
+#define S_DIPR_B 0x0C
+#define S_DIPR 0x00, 0x0C, SOCKET_BLOCK
 // Socket register block - Destination port register
-#define S_DPORT 0x00001008ul 
+#define S_DPORT_B 0x10
+#define S_DPORT 0x00, 0x10, SOCKET_BLOCK 
 // Free space in the outgoing TX register
-#define S_TX_FSR 0x00002008ul
-
-// Socket register block - Free space in the outgoing TX buffer
-#define S_TX_FSR 0x00002008ul
+#define S_TX_FSR_B 0x20
+#define S_TX_FSR 0x00, 0x20, SOCKET_BLOCK
 // Socket register block - TX buffer read pointer
-#define S_TX_RD 0x00002208ul
+#define S_TX_RD_B 0x22
+#define S_TX_RD 0x00, 0x22, SOCKET_BLOCK
 // Socket register block - TX buffer write pointer
-#define S_TX_WR 0x00002408ul
+#define S_TX_WR_B 0x24
+#define S_TX_WR 0x00, 0x24, SOCKET_BLOCK
 // Socket register block - RX buffer received size register
-#define S_RX_RSR 0x00002608ul
+#define S_RX_RSR_B 0x26
+#define S_RX_RSR 0x00, 0x26, SOCKET_BLOCK
 // Socket register block - RX buffer read pointer
-#define S_RX_RD 0x00002808ul
+#define S_RX_RD_B 0x28
+#define S_RX_RD 0x00, 0x28, SOCKET_BLOCK
 // Socket register block - RX buffer write pointer
-#define S_RX_WR 0x00002A08ul
-
+#define S_RX_WR_B 0x2A
+#define S_RX_WR 0x00, 0x2A, SOCKET_BLOCK
 // Socket register block - Socket interrupt mask
-#define S_IMR 0x00002C08ul
+#define S_IMR_B 0x2C
+#define S_IMR 0x00, 0x2C, SOCKET_BLOCK
 
-// Socket TX buffer
-#define S_TX_BUF 0x00000010ul
-// Socket RX buffer
-#define S_RX_BUF 0x00000018ul
-
-// Number of bytes in the registers above 
-#define S_MR_LEN 1
-#define S_CR_LEN 1
-#define S_IR_LEN 1
-#define S_SR_LEN 1
-#define S_PORT_LEN 2
-#define S_DHAR_LEN 6
-#define S_DIPR_LEN 4
-#define S_DPORT_LEN 2
-#define S_TX_FSR_LEN 2
-#define S_TX_RD_LEN 2
-#define S_TX_WR_LEN 2
-#define S_TX_RSR_LEN 2
-#define S_RX_RD_LEN 2
-#define S_RX_WR_LEN 2
-#define S_IMR_LEN 1

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -4,262 +4,267 @@
 
 #include "dhcp.h"
 
-const uint8_t macraw_frame[MACRAW_H_LEN] PROGMEM = {BROADCAST_MAC, MAC_ADDRESS, IPv4, 
-    IPv4_INFO, DIFFSERV, 0x00, 0x00, IPv4_ID, IPv4_FLAGS, TTL, PROTOCOL_UDP, 0x00, 0x00, NULL_IP_ADDR, BROADCAST_IP_ADDR, 
+const uint8_t macraw_frame[MACRAW_H_LEN] PROGMEM = {BROADCAST_MAC, MAC_ADDRESS, IPv4,
+    IPv4_INFO, DIFFSERV, 0x00, 0x00, IPv4_ID, IPv4_FLAGS, TTL, PROTOCOL_UDP, 0x00, 0x00, NULL_IP_ADDR, BROADCAST_IP_ADDR,
     UDP_SOURCE_PORT, UDP_DEST_PORT, 0x00, 0x00, 0x00, 0x00};
 const uint8_t dhcp_frame_start[DHCP_H_START_LEN] PROGMEM = {BOOTREQUEST, HTYPE, HLEN, HOPS, XID, [10] = FLAGS, [28] = MAC_ADDRESS};
 const uint8_t discover_options[DISCOVER_OPTIONS_LEN] PROGMEM = {MAGIC_COOKIE, MESSAGETYPE, DISCOVER, REQUESTED_IP, END, 0x00};
 const uint8_t request_options[REQUEST_OPTIONS_LEN] PROGMEM = {MAGIC_COOKIE, MESSAGETYPE, REQUEST, REQUESTED_IP, SERVER, DOMAIN_DATA, END};
 
+
 /* A single instance of DHCP Client for our use. */
 DHCP_Client DHCP;
+Socket DHCP_Socket;
 
 
 /* Message composition */
 /* Initializes W5500's IP data as null, and socket 0 as MACRAW */
-void setup_macraw(Socket *socket);
+void setup_macraw();
 /* Compiles a frame from various options, sends it to recipient. */
-void assemble_dhcp_frame(Socket *socket);
+void send_dhcp_frame();
 
 /* Incoming message analysis and verification */
 /* Reads a message in the buffer, checks whether it is a DHCP reply of some sort and extracts relevant
 information if it is. */
-void parse_packet(Socket *socket);
+void parse_packet();
 /* Checks whether a message's profile fits that of a DHCP reply. */
-bool check_if_dhcp(const Socket *socket, uint16_t read_pointer, uint16_t received_amount);
+int8_t check_if_dhcp(uint16_t read_pointer, uint16_t received_amount);
 /* Extracts information from a DHCP reply. */
-void read_dhcp_reply(Socket *socket, uint16_t read_pointer);
+void read_dhcp_reply(uint16_t read_pointer);
 
 /* Reads the contents of a buffer and pushes them out the UART line */
-void from_buffer_to_uart(uint32_t address, uint16_t pointer, uint16_t message_len);
+void from_wizchip_to_uart(uint16_t message_len);
 
 /* Writes packet lengths and IPv4 checksum into headers */
-void ipv4_header_prep(uint32_t address, uint16_t message_len);
+void ipv4_header_prep(uint16_t message_len);
 /* Calculates a CRC-32 frame check sequence used in an ethernet frame */
-void calculate_fcs(uint32_t address, uint16_t message_len);
+void calculate_fcs(uint16_t message_len);
 void shuffle_window(uint8_t *window);
 void xor_window(uint8_t *window);
 
+
+void dhcp_setup() {
+    ASSIGN(DHCP.our_ip, 0, 0, 0, 0, 0);
+    ASSIGN(DHCP.server, 0, 0, 0, 0, 0);
+    ASSIGN(DHCP.submask, 0, 0, 0, 0, 0);
+    DHCP.dhcp_status = DISCOVER;
+    DHCP.dhcp_lease_time = 0;
+
+    // Pushes DHCP network values (IP, server etc.) to W5500's network registers
+    set_network();
+
+    // Initialises socket 0 in MACRAW mode
+    setup_macraw();
+
+    // Send the first DHCP discover
+    send_dhcp_frame();
+}
+
 /* A continuously polled function that occasionally repeats requests */
-void dhcp_tracker(Socket *socket) {
-    DHCP.dhcp_lease_duration++;
-    
+void dhcp_tracker() {
+    DHCP.dhcp_lease_time++;
+
     switch (DHCP.dhcp_status) {
         case FRESH_ACQUIRED:
             DHCP.dhcp_status = ACQUIRED;
+            __attribute__ ((fallthrough));
         case ACQUIRED:
-            // Something to check remaining lease time and re-request if needed
-            if (DHCP.dhcp_lease_duration == DHCP.dhcp_lease_time) {
+            // Something to check remaining lease duration and re-request if needed
+            if (DHCP.dhcp_lease_time == UINT32_MAX) {
                 DHCP.dhcp_status = EXPIRED;
                 DHCP.dhcp_lease_time = 0;
                 break;
             }
-            if (DHCP.dhcp_lease_duration < (DHCP.dhcp_lease_time / 2)) {
-                DHCP.dhcp_lease_time++;
+            if (DHCP.dhcp_lease_time < (UINT32_MAX >> 1)) {
                 break;
             }
-            DHCP.dhcp_status = REREQUEST;
-            assemble_dhcp_frame(socket);
+            DHCP.dhcp_status = REQUEST;
+            setup_macraw();
+            send_dhcp_frame();
             break;
-        case REREQUEST:
-            // Don't spam the router
-            if (DHCP.dhcp_lease_duration < MESSAGE_DELAY) {
-                break;
-            }
-            assemble_dhcp_frame(socket);
-            break;
+        // Default back to discover if something goes wrong
+        default:
         // Assume that everything will have changed after expiration
         case EXPIRED:
-        case DISCOVER:
-        // Or default back to discover if something goes wrong
-        default:
             DHCP.dhcp_status = DISCOVER;
+            setup_macraw();
+            __attribute__ ((fallthrough));
+        case DISCOVER:
         case REQUEST:
             // Don't spam the router
-            if (DHCP.dhcp_lease_duration < MESSAGE_DELAY) {
+            if (DHCP.dhcp_lease_time < MESSAGE_DELAY) {
                 break;
             }
-            assemble_macraw_frame(socket);
+            send_dhcp_frame();
             break;
     }
 }
 
 /* Interrupt handler for incoming messages */
-void dhcp_interrupt(Socket *socket) {
+void dhcp_interrupt() {
     if (DHCP.dhcp_status == ACQUIRED) {
         return;
     }
-    parse_packet(socket);
+    parse_packet();
 }
 
 void set_network() {
     uint8_t array[6] = {MAC_ADDRESS};
-    write(SHAR, 6, array);
-    write(SIPR, 4, DHCP.our_ip);
-    write(GAR, 4, DHCP.server);
-    write(SUBR, 4, DHCP.submask);
+    set_address(SHAR);
+    write(6, array);
+
+    set_half_address(SIPR_B);
+    write(4, DHCP.our_ip);
+
+    set_half_address(GAR_B);
+    write(4, DHCP.server);
+
+    set_half_address(SUBR_B);
+    write(4, DHCP.submask);
 }
 
-void setup_macraw(Socket *socket) {    
-    // Set up socket
-    socket_initialise(socket, MACRAW_MODE, CLIENT_PORT, RECV_INT);
-
-    /* Prep the socket for the first, broadcast, transmission */
-    // Mac address to 42-36-EE-E0-34-AB
-    uint8_t array[] = {MAC_ADDRESS};
-    write(SHAR, 6, array);
-    
-    // Our IP
-    write_singular(SIPR, 4, 0x00);
-    // Default gateway
-    write_singular(GAR, 4, 0x00);
-    // Default subnet mask
-    write_singular(SUBR, 4, 0x00);
+void setup_macraw() {
+    socket_initialise(&DHCP_Socket, MACRAW_MODE, CLIENT_PORT, RECV_INT);
 
     // Destination address to 255.255.255.255 for broadcast
-    write_singular(S_DIPR, 4, 0xFF);
-    // Set the destination MAC to FF-FF-FF-FF-FF-FF
-    write_singular(S_DHAR, 6, 0xFF);
+    set_address(S_DIPR);
+    embed_socket(1);
+    write_singular(4, 0xFF);
+
+    // Set the destination MAC to FF-FF-FF-FF-FF-FF for broadcast
+    set_half_address(S_DHAR_B);
+    write_singular(6, 0xFF);
 
     // Destination port to 67 for DHCP server
-    array[0] = (SERVER_PORT >> 8);
-    array[1] = SERVER_PORT;
-    write(S_DPORT, 2, array);
+    uint8_t array[] = {(SERVER_PORT >> 8), SERVER_PORT};
+    set_half_address(S_DPORT_B);
+    write(2, array);
 
-    socket_open(socket);
-    socket_toggle_interrupts(socket, 1);
+    socket_open(&DHCP_Socket);
+    socket_toggle_interrupts(&DHCP_Socket, ON);
 }
 
 
-void assemble_macraw_frame(Socket *socket) {
-    setup_macraw(socket);
+void send_dhcp_frame() {
+    setup_macraw();
 
-    uint32_t tx_address = S_TX_BUF;
-    uint16_t pointer = socket->tx_pointer;
+    uint16_t pointer = DHCP_Socket.tx_pointer;
+    // Used for both tracking initial pointer position and to hold the message length
+    uint16_t placeholder = DHCP_Socket.tx_pointer;
+
+    set_address((pointer >> 8), pointer, S_TX_BUF_BLOCK);
 
     /* Step 1: write in the link layer + IPv4 + UDP headers */
-    tx_address = EMBEDADDRESS(tx_address, socket->tx_pointer);
-    write_P(tx_address, MACRAW_H_LEN, macraw_frame);
-    socket->tx_pointer += MACRAW_H_LEN;
+    write_P(MACRAW_H_LEN, macraw_frame);
+    pointer += MACRAW_H_LEN;
 
-    /* Write in the DHCP packet */
-    assemble_dhcp_frame(socket);
-
-    /* Write in IPv4 checksum and packet section lengths */
-    ipv4_header_prep(EMBEDADDRESS(tx_address, pointer), (socket->tx_pointer - pointer));
-
-    /* Write in the link layer footer / checksum */
-    calculate_fcs(EMBEDADDRESS(tx_address, pointer), (socket->tx_pointer - pointer));
-    socket->tx_pointer += 4;
-
-    // Debug
-    //from_buffer_to_uart(tx_address, pointer, (socket->tx_pointer - pointer));
-
-    socket_send_message(socket);
-
-    DHCP.dhcp_lease_duration = 0;
-}
-
-/* Compiles a frame from various options, sends it to recipient. */
-void assemble_dhcp_frame(Socket *socket) {
-    uint32_t tx_address = S_TX_BUF;
-    uint16_t pointer = socket->tx_pointer;
-
-    // Embed the write pointer to the address to get a starting point
-    tx_address = EMBEDADDRESS(tx_address, socket->tx_pointer);
-    
     // Send in the base frame start
-    write_P(tx_address, DHCP_H_START_LEN, dhcp_frame_start);
-    socket->tx_pointer += DHCP_H_START_LEN;
+    embed_pointer(pointer);
+    write_P(DHCP_H_START_LEN, dhcp_frame_start);
+    pointer += DHCP_H_START_LEN;
 
     // Fill rest of hardware address and additional options with zeroes
-    tx_address = EMBEDADDRESS(tx_address, socket->tx_pointer);
-    write_singular(tx_address, DHCP_H_ZEROES, 0x00);
-    socket->tx_pointer += DHCP_H_ZEROES;
-
-    // Set the pointer to the start of the options block
-    pointer = socket->tx_pointer;
+    embed_pointer(pointer);
+    write_singular(DHCP_H_ZEROES, 0x00);
+    pointer += DHCP_H_ZEROES;
 
     // Write in options
-    tx_address = EMBEDADDRESS(tx_address, socket->tx_pointer);
+    embed_pointer(pointer);
     if ((DHCP.dhcp_status & 0x0F) == DISCOVER) {
-        write_P(tx_address, DISCOVER_OPTIONS_LEN, discover_options);
-        socket->tx_pointer += DISCOVER_OPTIONS_LEN;
+        write_P(DISCOVER_OPTIONS_LEN, discover_options);
+        pointer += DISCOVER_OPTIONS_LEN;
     }
     if ((DHCP.dhcp_status & 0x0F) == REQUEST) {
-        write_P(tx_address, REQUEST_OPTIONS_LEN, request_options);
-        socket->tx_pointer += REQUEST_OPTIONS_LEN;
+        write_P(REQUEST_OPTIONS_LEN, request_options);
+        pointer += REQUEST_OPTIONS_LEN;
 
         // Write the server we're requesting the IP from to both options and SIADDR
-        tx_address = EMBEDADDRESS(tx_address, (pointer - DHCP_H_ZEROES - SIADDR_TO_ZEROES_STEP));
-        write(tx_address, 4, DHCP.server);
-        tx_address = EMBEDADDRESS(tx_address, (pointer + 15));
-        write(tx_address, 4, DHCP.server);
+        embed_pointer(placeholder + SIADDR_STEP);
+        write(4, DHCP.server);
+        embed_pointer(placeholder + MAGIC_COOKIE_STEP + COOKIE_TO_SERVER_STEP);
+        write(4, DHCP.server);
     }
 
     // Write in our requested IP address
-    tx_address = EMBEDADDRESS(tx_address, (pointer + 9));
-    write(tx_address, 4, DHCP.our_ip);
+    embed_pointer(placeholder + REQUESTED_IP_STEP);
+    write(4, DHCP.our_ip);
+
+    // Set the write pointer back to the start of the message for checksums
+    embed_pointer(placeholder);
+    // Store message length in placeholder
+    placeholder = pointer - placeholder;
+
+    /* Write in IPv4 checksum and packet section lengths */
+    ipv4_header_prep(placeholder);
+
+    /* Write in the link layer footer / checksum */
+    calculate_fcs(placeholder);
+    pointer += 4;
+    placeholder += 4;
+
+    DHCP_Socket.tx_pointer = pointer;
+
+    #ifdef DEBUG
+        from_wizchip_to_uart(placeholder);
+    #endif
+
+    socket_send_message(&DHCP_Socket);
+
+    DHCP.dhcp_lease_time = 0;
 }
 
-void parse_packet(Socket *socket) {
-    uart_write_P(PSTR("DHCP parser.\r\n"));
-    
-    uint32_t rx_addr = S_RX_BUF;
 
+void parse_packet() {
     // Check where you left off reading
-    uint16_t rx_pointer = get_2_byte(S_RX_RD);
+    set_address(S_RX_RD);
+    uint16_t rx_pointer = get_2_byte();
 
     // Get the length info from the RX buffer (it's written as two bytes before the actual message)
+    set_address((rx_pointer >> 8), rx_pointer, S_RX_BUF_BLOCK);
     uint8_t buf[2];
-    rx_addr = EMBEDADDRESS(rx_addr, rx_pointer);
-    read(rx_addr, buf, 2, 2);
-    uint16_t received_amount = (((uint16_t)buf[0] << 8) + (uint16_t)buf[1]);
+    read(buf, 2, 2);
+    uint16_t received_amount = (((uint16_t)buf[0] << 8) | buf[1]);
     // Adjust pointers to account for the two extra bytes taken by the length info
-    
-    // Don't let a misaligned pointer trap you in a loop of always reading zero and never moving forward
-    if (received_amount < 3) {
-        received_amount = get_2_byte(S_RX_RSR);
-        // Update read pointer to mark the segment as read
-        buf[0] = received_amount >> 8;
-        buf[1] = received_amount;
-        write(S_RX_RD, 2, buf);
-        buf[0] = RECV;
-        write(S_CR, 1, buf);
-        return;
-    }
     received_amount -= 2;
     rx_pointer += 2;
-    
-    /* Check whether the message looks like it's DHCP and read it if it is */
-    if (check_if_dhcp(socket, rx_pointer, received_amount)) {
-        read_dhcp_reply(socket, rx_pointer);
-    }
 
-    // Debug
-    from_buffer_to_uart(rx_addr, rx_pointer, received_amount);
+    #ifdef DEBUG
+        print_buffer(buf, 2, 2);
+        uart_write(".");
+    #endif
 
-    if (DHCP.dhcp_status == FRESH_ACQUIRED) {
+    // Don't let a misaligned pointer trap you in a loop of always reading zero and never moving forward, or to reading massive amounts
+    if (received_amount == 0 || received_amount > 0x02FF) {
+        set_address(S_RX_RSR);
+        received_amount = get_2_byte();
+        // Update read pointer to mark the buffer as read
+        socket_update_read_pointer(&DHCP_Socket, received_amount);
+
         return;
     }
+
+    /* Check whether the message looks like it's DHCP and read it if it is */
+    int8_t is_dhcp = check_if_dhcp(rx_pointer, received_amount);
+    if (is_dhcp > 0) {
+        read_dhcp_reply(rx_pointer);
+    }
+
+    #ifdef DEBUG
+        print_buffer(&is_dhcp, 1, 1);
+        set_address((rx_pointer >> 8), rx_pointer, S_RX_BUF_BLOCK);
+        from_wizchip_to_uart(received_amount);
+    #endif
 
     // Update read pointer to mark the segment as read
     rx_pointer += received_amount;
-    buf[0] = rx_pointer >> 8;
-    buf[1] = rx_pointer;
-    write(S_RX_RD, 2, buf);
-    buf[0] = RECV;
-    write(S_CR, 1, buf);
+    socket_update_read_pointer(&DHCP_Socket, rx_pointer);
 }
 
-bool check_if_dhcp(const Socket *socket, uint16_t read_pointer, uint16_t received_amount) {
-    uint32_t address = EMBEDADDRESS(S_RX_BUF, read_pointer);
-
-    // If the socket is in MACRAW mode, there are extra ethernet layers included to account for. 
-    uint16_t offset = ((socket->mode == MACRAW_MODE) ? MACRAW_H_LEN : 0);
+int8_t check_if_dhcp(uint16_t read_pointer, uint16_t received_amount) {
+    set_address((read_pointer >> 8), read_pointer, S_RX_BUF_BLOCK);
 
     // Too short?
-    if (received_amount < (252 + offset)) {
+    if (received_amount < 294) {
         return 0;
     }
 
@@ -267,99 +272,92 @@ bool check_if_dhcp(const Socket *socket, uint16_t read_pointer, uint16_t receive
 
     // If you're in the request stage, only accept an offer from one server
     if (DHCP.dhcp_status == REQUEST) {
-        address = EMBEDADDRESS(address, (read_pointer + offset + SIADDR_STEP));
-        read(address, buffer, 6, 4);
-        if (do_arrays_differ(buffer, DHCP.server, 4)) {
-            return 0;
+        embed_pointer(read_pointer + UDP_SOURCE_STEP);
+        read(buffer, 6, 4);
+        if (memcmp(buffer, DHCP.server, 4)) {
+            return -1;
         }
     }
 
     // Check the receiver MAC (CHADDR field in DHCP packet) to see if the message is directed to you
-    offset += CHADDR_STEP;
-    address = EMBEDADDRESS(address, (read_pointer + offset));
+    read_pointer += CHADDR_STEP;
+    embed_pointer(read_pointer);
     uint8_t comp[6] = {MAC_ADDRESS};
-    read(address, buffer, 6, 6);
-    if (do_arrays_differ(buffer, comp, 6)) {
-        return 0;
+    read(buffer, 6, 6);
+    print_buffer(buffer, 6, 6);
+    print_buffer(comp, 6, 6);
+    if (memcmp(buffer, comp, 6)) {
+        return -2;
     }
 
     // Look for the magic cookie
-    ASSIGN(comp, 0, MAGIC_COOKIE);   
-    offset += CHADDR_TO_COOKIE_STEP;
-    address = EMBEDADDRESS(address, (read_pointer + offset));
-    read(address, buffer, 6, 4);
-    if (do_arrays_differ(buffer, comp, 4)) {
-        return 0;
+    ASSIGN(comp, 0, MAGIC_COOKIE);
+    read_pointer += CHADDR_TO_COOKIE_STEP;
+    embed_pointer(read_pointer);
+    read(buffer, 6, 4);
+    if (memcmp(buffer, comp, 4)) {
+        return -3;
     }
 
-    // Make sure the message type follows the one you last sent (such as discover being followed by offer)
-    offset += 6;
-    address = EMBEDADDRESS(address, (read_pointer + offset));
-    read(address, buffer, 6, 1);
-    if (buffer[0] <= (DHCP.dhcp_status & 0x0F)) {
-        return 0;
+    // Message type checks
+    read_pointer += COOKIE_TO_MTYPE_STEP;
+    embed_pointer(read_pointer);
+    read(buffer, 6, 1);
+    // If your request is refused, start the discovery process over again
+    if (buffer[0] == PNAK) {
+        DHCP.dhcp_status = DISCOVER;
+        return -4;
+    }
+
+    // Make sure the message type is something that would come after what you sent (such as discover being followed by offer)
+    if (!(buffer[0] > (DHCP.dhcp_status & 0x0F))) {
+        return -5;
     }
 
     return 1;
 }
 
-void read_dhcp_reply(Socket *socket, uint16_t read_pointer) {
-    uart_write_P(PSTR("Received a DHCP reply!\r\n"));
+void read_dhcp_reply(uint16_t read_pointer) {
+    // When the socket is in MACRAW mode, there are extra ethernet layers included to account for.
+    set_address((read_pointer >> 8), read_pointer, S_RX_BUF_BLOCK);
 
-    // Adjust pointer if there are link layer headers involved
-    read_pointer = (socket->mode == MACRAW_MODE ? (read_pointer + MACRAW_H_LEN) : read_pointer);
-    
     uint8_t data[6] = {0};
 
     /* Take note of the server's address and our offered IP */
     // The offered IP
-    read(EMBEDADDRESS(S_RX_BUF, (read_pointer + YIADDR_STEP)), data, 4, 4);
+    embed_pointer(read_pointer + YIADDR_STEP);
+    read(data, 4, 4);
     ASSIGN(DHCP.our_ip, 0, data[0], data[1], data[2], data[3]);
-    
+
     // The server doing the offering
-    read(EMBEDADDRESS(S_RX_BUF, (read_pointer + SIADDR_STEP)), data, 4, 4);
+    embed_pointer(read_pointer + SIADDR_STEP);
+    read(data, 4, 4);
     ASSIGN(DHCP.server, 0, data[0], data[1], data[2], data[3]);
-    
+
     if ((DHCP.dhcp_status & 0x0F) == DISCOVER) {
         DHCP.dhcp_status = REQUEST;
     }
     /* Assign network info upon a granted request */
     else if ((DHCP.dhcp_status & 0x0F) == REQUEST) {
-        // Get lease time
-        read(EMBEDADDRESS(S_RX_BUF, (read_pointer + MAGIC_COOKIE_STEP + COOKIE_TO_LEASE_STEP)), data, 4, 4);
-        // As we don't have a real clock and the time is in seconds, 
-        // induce some semblance of delay by requiring a large number of cycles
-        if (data[1] == 0) {
-            ASSIGN(data, 0, 0x7F, 0xFF, 0xFF, 0xF0);
-        } else {
-            ASSIGN(data, 0, 0xFF, 0xFF, 0xFF, 0xF0);
-        }
-        DHCP.dhcp_lease_duration = ((uint32_t)data[0] << 24 | (uint32_t)data[1] << 16 | (uint16_t)data[2] << 8 | data[3]);
-
         DHCP.dhcp_status = FRESH_ACQUIRED;
-        DHCP.dhcp_lease_duration = 0;
+        DHCP.dhcp_lease_time = 0;
 
         // Get subnet mask
-        read(EMBEDADDRESS(S_RX_BUF, (read_pointer + MAGIC_COOKIE_STEP + COOKIE_TO_SUBNET_STEP)), DHCP.submask, 4, 4);
+        embed_pointer(read_pointer + MAGIC_COOKIE_STEP + COOKIE_TO_SUBNET_STEP);
+        read(DHCP.submask, 4, 4);
 
-        // Reset Wizchip
-        socket_close(socket);
-        write_singular(MR, 1, 0x80);
+        socket_close(&DHCP_Socket);
 
         set_network();
 
         print_ip();
-
-        // Switch the socket to UDP
-        socket_initialise(socket, UDP_MODE, CLIENT_PORT, RECV_INT);
-        socket_open(socket);
     }
 }
 
 void print_ip() {
     uint8_t array[4];
 
-    uart_write("Acquired IP address: ");
+    uart_write_P(PSTR("Acquired IP address: "));
     for (uint8_t i = 0; i < 4; i++) {
         utoa(DHCP.our_ip[i], array, 10);
         print_buffer(array, sizeof(array), 3);
@@ -370,45 +368,56 @@ void print_ip() {
     uart_write("\r\n");
 }
 
-void from_buffer_to_uart(uint32_t address, uint16_t pointer, uint16_t message_len) {
+void from_wizchip_to_uart(uint16_t message_len) {
     uart_write("...");
 
+    // Take note of the original address
+    uint8_t old_address[3] = {wizchip_address[0], wizchip_address[1], wizchip_address[2]};
+    uint16_t pointer = ((uint16_t)wizchip_address[0] << 8) | wizchip_address[1];
+
     uint8_t buffer[10] = {0};
-        
+
     for (uint16_t left = message_len; left > 0;) {
-        address = EMBEDADDRESS(address, pointer);
-        read(address, buffer, 10, left);
+        embed_pointer(pointer);
+        read(buffer, 10, left);
         print_buffer(buffer, 10, left);
         pointer += MIN(10, left);
         left -= MIN(left, 10);
     }
 
-    uart_write("---");
+    // Revert the original address
+    set_address(old_address[0], old_address[1], old_address[2]);
+
+    uart_write("...");
 }
 
 /* Writes length data and IPv4 checksum into the headers */
-void ipv4_header_prep(uint32_t address, uint16_t message_len) {
-    uint16_t pointer = (address & 0x00FFFF00ul) >> 8;
+void ipv4_header_prep(uint16_t message_len) {
+    // Take note of the original address
+    uint8_t old_address[] = {wizchip_address[0], wizchip_address[1], wizchip_address[2]};
+
+    uint16_t pointer = ((uint16_t)wizchip_address[0] << 8) | wizchip_address[1];
+
     // Adjust the pointer to account for the ethernet header
     pointer += ETH_H_LEN;
 
     // UDP packet length
     uint8_t data[2] = {((message_len - ETH_H_LEN - IPv4_H_LEN) >> 8), (message_len - ETH_H_LEN - IPv4_H_LEN)};
-    address = EMBEDADDRESS(address, (pointer + UDP_LENGTH_STEP));
-    write(address, 2, data);
-    
+    embed_pointer(pointer + UDP_LENGTH_STEP);
+    write(2, data);
+
     // IPv4 packet length
     data[0] = (message_len - ETH_H_LEN) >> 8;
     data[1] = message_len - ETH_H_LEN;
-    address = EMBEDADDRESS(address, (pointer + IPv4_LENGTH_STEP));
-    write(address, 2, data);
+    embed_pointer(pointer + IPv4_LENGTH_STEP);
+    write(2, data);
 
     /* IPv4 header checksum */
     // Data is read two bytes at a time and those two bytes are added to the sum
     uint32_t sum = 0;
     for (uint8_t i = 0; i < (IPv4_H_LEN / 2); i += 2) {
-        address = EMBEDADDRESS(address, (pointer + i));
-        read(address, data, 2, 2);
+        embed_pointer(pointer + i);
+        read(data, 2, 2);
         sum += ((uint16_t)data[0] << 8) + data[1];
     }
 
@@ -423,17 +432,23 @@ void ipv4_header_prep(uint32_t address, uint16_t message_len) {
     // And finally the checksum is written in
     data[0] = sum >> 8;
     data[1] = sum;
-    address = EMBEDADDRESS(address, (pointer + IPv4_CHECKSUM_STEP));
-    write(address, 2, data);
+    embed_pointer(pointer + IPv4_CHECKSUM_STEP);
+    write(2, data);
+
+    // Revert the original address
+    set_address(old_address[0], old_address[1], old_address[2]);
 }
 
 
 /* Ethernet uses a CRC-32-calculated frame check sequence for error detection. */
 /* Thank you to vafylec for the guide to CRC-32 */
-void calculate_fcs(uint32_t address, uint16_t message_len) {
-    uint16_t pointer = (address & 0x00FFFF00ul) >> 8;
+void calculate_fcs(uint16_t message_len) {
+    // Take note of the original address
+    uint8_t old_address[] = {wizchip_address[0], wizchip_address[1], wizchip_address[2]};
+
+    uint16_t pointer = ((uint16_t)wizchip_address[0] << 8) | wizchip_address[1];
     uint8_t window[4] = {0}, message[4] = {0};
-    
+
     uint16_t step = 0;
     uint16_t read_len = 0;
 
@@ -443,10 +458,10 @@ void calculate_fcs(uint32_t address, uint16_t message_len) {
         step = MIN((message_len + 4) - i, 4);
         read_len = (((message_len - i) > message_len) ? 0 : (message_len - i));
         read_len = (read_len > 0xFF ? 0xFF : read_len);
-        address = EMBEDADDRESS(address, pointer);
+        embed_pointer(pointer);
 
         ASSIGN(message, 0, 0, 0, 0, 0);
-        read_reversed(address, message, 4, read_len);
+        read_reversed(message, 4, read_len);
 
         // The very first bytes are inverted
         if (i == 0) {
@@ -473,18 +488,18 @@ void calculate_fcs(uint32_t address, uint16_t message_len) {
                     window[3] |= EXTRACTBIT(message[j], (k - 1));
                 }
             }
-        } 
+        }
     }
 
     // XOR and reverse the bytes
-    window[0] = reverse_byte(~window[0]);
-    window[1] = reverse_byte(~window[1]);
-    window[2] = reverse_byte(~window[2]);
-    window[3] = reverse_byte(~window[3]);
-    
+    ASSIGN(window, 0, reverse_byte(~window[0]), reverse_byte(~window[1]), reverse_byte(~window[2]), reverse_byte(~window[3]));
+
     // Write frame check sequence at the end of the header
-    address = EMBEDADDRESS(address, pointer);
-    write(address, 4, window);
+    embed_pointer(pointer);
+    write(4, window);
+
+    // Revert the original address
+    set_address(old_address[0], old_address[1], old_address[2]);
 }
 
 void shuffle_window(uint8_t *window) {

--- a/src/main.c
+++ b/src/main.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include "w5500.h"
 
-const char content[] PROGMEM = "HTTP/1.1 OK\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html><html><body><h1>Test</h1></body></html>";
+const char content[] PROGMEM = "HTTP/1.1 OK 200\r\nContent-Type: text/html\r\n\r\n<!DOCTYPE html><html><body><h1>Test</h1></body></html>";
 
 void socket_init();
 void check_interrupts();
@@ -12,33 +12,15 @@ uint16_t counter = 0;
 int main(void) {
     // IP address & other setup
     setup_wizchip();
+
+    socket_init();
+
     for (;;) {
-        /*counter++;
-        if (counter > 0xFFF0) {
-            uint8_t status[4] = {0};
-            read(S_SR, status, 1, 1);
-            print_buffer(status, 1, 1);
-            read(S_SR | SOCKETMASK(1), status, 1, 1);
-            print_buffer(status, 1, 1);
-            uart_write(".");
-            read(SIPR, status, 4, 4);
-            print_buffer(status, 4, 4);
-            uart_write(".");
-            read(GAR, status, 4, 4);
-            print_buffer(status, 4, 4);
-            uart_write(".");
-            read(SUBR, status, 4, 4);
-            print_buffer(status, 4, 4);
-            uart_write(".");
-            read(SIR, status, 2, 2);
-            print_buffer(status, 2, 2);
-            counter = 0;
-        }*/
         // Initialises server socket once an IP has been acquired
         if (DHCP.dhcp_status == FRESH_ACQUIRED) {
             socket_init();
         }
-        dhcp_tracker(&Wizchip.sockets[DHCP_SOCKET]);
+        dhcp_tracker();
         check_interrupts();
     }
 
@@ -47,20 +29,18 @@ int main(void) {
 
 void socket_init() {
     // Opens socket 1 to TCP listening state on port 9999
-    tcp_socket_initialise(&Wizchip.sockets[1], 9999, (RECV_INT | DISCON_INT));
+    tcp_socket_initialise(9999, (RECV_INT | DISCON_INT));
     uint8_t err;
     do {
-        err = tcp_listen(&Wizchip.sockets[1]);
+        err = tcp_listen();
     } while (err);
 }
 
-void check_interrupts() {        
+void check_interrupts() {
     // Check the list for a new interrupt
     if (Wizchip.interrupt_list_index == 0) {
         return;
     }
-
-    uart_write_P(PSTR("Interrupt called.\r\n"));
 
     // Extract the socket number from the list
     uint8_t interrupt = Wizchip.interrupt_list[0];
@@ -68,30 +48,27 @@ void check_interrupts() {
 
     // DHCP operations, do not touch
     if (sockno == DHCP_SOCKET) {
-        dhcp_interrupt(&Wizchip.sockets[DHCP_SOCKET]);
+        dhcp_interrupt();
         shuffle_interrupts();
         return;
     }
-
 
     /* User code below */
 
     uint8_t buffer[20] = {0};
 
-    tcp_read_received(&Wizchip.sockets[sockno], buffer, 20);
+    tcp_read_received(buffer, 20);
     print_buffer(buffer, 20, 20);
 
     if (interrupt & RECV_INT) {
-        uart_write_P(PSTR("Recv_int.\r\n"));
-        tcp_send(&Wizchip.sockets[sockno], sizeof(content), content, OP_PROGMEM);
-        tcp_disconnect(&Wizchip.sockets[sockno]);
+        tcp_send(sizeof(content), content, OP_PROGMEM);
+        tcp_disconnect();
     }
 
     if (interrupt & DISCON_INT) {
-        uart_write_P(PSTR("Discon_int.\r\n"));
         uint8_t err;
         do {
-            err = tcp_listen(&Wizchip.sockets[sockno]);
+            err = tcp_listen();
         } while (err);
     }
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -5,96 +5,120 @@
 #include "socket.h"
 
 
+void embed_pointer(uint16_t pointer) {
+    wizchip_address[0] = (pointer >> 8);
+    wizchip_address[1] = pointer;
+}
+
+void set_address(uint8_t byte_one, uint8_t byte_two, uint8_t block) {
+    wizchip_address[0] = byte_one;
+    wizchip_address[1] = byte_two;
+    wizchip_address[2] = block;
+}
+
 /* Attaches port number, interrupt mask and mode of operation to socket */
 void socket_initialise(Socket *socket, uint8_t mode, uint16_t portno, uint8_t interrupt_mask) {
-    uint32_t port_addr = S_PORT | SOCKETMASK(socket->sockno);
-    uint32_t mode_addr = S_MR | SOCKETMASK(socket->sockno);
-    uint32_t tx_wr_addr = S_TX_WR | SOCKETMASK(socket->sockno);
-
     // Assign port to socket, write portno into the socket's registers
     socket->portno = portno;
     uint8_t port[] = {(portno >> 8), portno};
-    write(port_addr, 2, port);
+    set_address(S_PORT);
+    embed_socket(socket->sockno);
+    write(2, port);
 
     // Set socket mode (TCP, UDP or MACRAW)
     socket->mode = mode;
-    write(mode_addr, 1, &socket->mode);
+    set_half_address(S_MR_B);
+    write(1, &socket->mode);
 
     // Assign interrupt mask to socket, write to socket
     socket->interrupts = interrupt_mask;
-    socket_toggle_interrupts(socket, 0);
+    socket_toggle_interrupts(socket, OFF);
 
     // Gets the socket's current TX buffer write pointer, takes note for future writes
-    socket->tx_pointer = get_2_byte(tx_wr_addr);
+    set_half_address(S_TX_WR_B);
+    socket->tx_pointer = get_2_byte();
 }
 
 /* Opens socket, updates struct's tx write pointer to match the current read pointer as that gets initialised with socket opens */
 void socket_open(Socket *socket) {
-    uint32_t com_addr = S_CR | SOCKETMASK(socket->sockno);
-    uint32_t read_pointer_addr = S_TX_RD | SOCKETMASK(socket->sockno);
-
     // Open socket
     uint8_t command = OPEN;
-    write(com_addr, 1, &command);
+    set_address(S_CR);
+    embed_socket(socket->sockno);
+    write(1, &command);
 
     if (socket->mode != TCP_MODE) {
-        socket_toggle_interrupts(socket, 1);
+        socket_toggle_interrupts(socket, ON);
     }
 
-    // 
-    socket->tx_pointer = get_2_byte(read_pointer_addr);
+    //
+    set_half_address(S_TX_RD_B);
+    socket->tx_pointer = get_2_byte();
 }
 
 /* Self-explanatory. */
 void socket_close(const Socket *socket) {
-    uint32_t com_addr = S_CR | SOCKETMASK(socket->sockno);
-
     uint8_t close = CLOSE;
-    write(com_addr, 1, &close);
+    set_address(S_CR);
+    embed_socket(socket->sockno);
+    write(1, &close);
 
-    socket_toggle_interrupts(socket, 0);
+    socket_toggle_interrupts(socket, OFF);
 }
 
 /* Reads the socket's status register into the socket struct */
 void socket_get_status(Socket *socket) {
-    uint32_t status_addr = S_SR | SOCKETMASK(socket->sockno);
-
-    read(status_addr, &socket->status, 1, S_SR_LEN);
+    set_address(S_SR);
+    embed_socket(socket->sockno);
+    read(&socket->status, 1, 1);
 }
 
-/*  Toggles a socket's interrupts on or off based on the socket's interrupt mask. 
+/*  Toggles a socket's interrupts on or off based on the socket's interrupt mask.
     Will always include a CON_INT for TCP sockets for pointer tracking purposes, even if not requested by user. */
 void socket_toggle_interrupts(const Socket *socket, bool set_on) {
-    uint32_t gen_interrupt_mask_addr = SIMR;
-    uint32_t sock_interrupt_mask_addr = S_IMR | SOCKETMASK(socket->sockno);
-
     // Get existing socket interrupt mask register
     uint8_t simr = 0;
-    read(gen_interrupt_mask_addr, &simr, 1, SIMR_LEN);
+    set_address(SIMR);
+    embed_socket(socket->sockno);
+    read(&simr, 1, 1);
 
     // Embed socket number into it, write
     simr &= ~_BV(socket->sockno);
     simr |= (set_on << socket->sockno);
-    write(gen_interrupt_mask_addr, 1, &simr);
+    write(1, &simr);
 
     // TCP connection events affect buffer pointers and need to be accounted for in the ISR
     // regardless of whether the end user cares about them
     uint8_t interrupts = ((socket->mode == TCP_MODE) ? (socket->interrupts | CON_INT) : socket->interrupts);
 
     // Send a list of accepted interrupts for the socket
-    write(sock_interrupt_mask_addr, 1, &interrupts);
+    set_address(S_IMR);
+    embed_socket(socket->sockno);
+    write(1, &interrupts);
+}
+
+void socket_update_read_pointer(const Socket *socket, uint16_t read_pointer) {
+    uint8_t pointer[] = {(read_pointer >> 8), read_pointer};
+
+    set_address(S_RX_RD);
+    embed_socket(socket->sockno);
+    write(2, pointer);
+
+    uint8_t recv = RECV;
+    set_half_address(S_CR_B);
+    write(1, &recv);
 }
 
 /* Updates the socket's TX write pointer register and commands the W5500 to transmit the contents of socket TX buffer. */
-void socket_send_message(Socket *socket) {
-    uint32_t tx_pointer_addr = S_TX_WR | SOCKETMASK(socket->sockno);
-    uint32_t send_addr = S_CR | SOCKETMASK(socket->sockno);
-
+void socket_send_message(const Socket *socket) {
     // Write a new value to the TX buffer write pointer to match post-input situation
     uint8_t new_tx_write_pointer[2] = {(socket->tx_pointer >> 8), socket->tx_pointer};
-    write(tx_pointer_addr, 2, new_tx_write_pointer);
+    set_address(S_TX_WR);
+    embed_socket(socket->sockno);
+    write(2, new_tx_write_pointer);
 
     // Send the "send" command to pass the message to the other party
     uint8_t send = (socket->mode == MACRAW_MODE ? SEND_MAC : SEND);
-    write(send_addr, 1, &send);
+    set_half_address(S_CR_B);
+    write(1, &send);
 }

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -4,27 +4,24 @@
 
 #include "tcp.h"
 
+Socket TCP_Socket;
 
 /* Basic setup to get the socket ready for operation. */
-void tcp_socket_initialise(Socket *socket, uint16_t portno, uint8_t interrupts) {
-    socket_initialise(socket, TCP_MODE, portno, interrupts);
+void tcp_socket_initialise(uint16_t portno, uint8_t interrupts) {
+    socket_initialise(&TCP_Socket, TCP_MODE, portno, interrupts);
 }
 
 /*  Puts the socket into TCP listen mode. 
     If the socket setup doesn't proceed as expected, returns the status code of the socket. */ 
-uint8_t tcp_listen(Socket *socket) {
-    uart_write_P(PSTR("TCP listen.\r\n"));
-
-    uint32_t com_addr = S_CR | SOCKETMASK(socket->sockno);
-    uint32_t status_addr = S_SR | SOCKETMASK(socket->sockno);
-
-    socket_open(socket);
+uint8_t tcp_listen() {
+    socket_open(&TCP_Socket);
 
     // Ensure that the socket is ready to take a listen command
     uint8_t status = 0;
     uint8_t killswitch = 0;
+    set_half_address(S_SR_B);
     do {
-        read(status_addr, &status, 1, S_SR_LEN);
+        read(&status, 1, 1);
         killswitch++;
         if (killswitch > 100) {
             return status;
@@ -32,13 +29,15 @@ uint8_t tcp_listen(Socket *socket) {
     } while (status != SOCK_INIT);
 
     // Get the socket listening
+    set_half_address(S_CR_B);
     uint8_t command = LISTEN;
-    write(com_addr, 1, &command);
+    write(1, &command);
 
     // Make sure the socket is in fact listening
     killswitch = 0;
+    set_half_address(S_SR_B);
     do {
-        read(status_addr, &status, 1, S_SR_LEN);
+        read(&status, 1, 1);
         killswitch++;
         if (killswitch > 100) {
             return status;
@@ -47,7 +46,7 @@ uint8_t tcp_listen(Socket *socket) {
     } while (status != SOCK_LISTEN && status != SOCK_ESTABLISHED);
     
     // Enable interrupts for the socket
-    socket_toggle_interrupts(socket, 1);
+    socket_toggle_interrupts(&TCP_Socket, ON);
 
     return 0;
 }
@@ -56,37 +55,35 @@ uint8_t tcp_listen(Socket *socket) {
     Operands: 
     - OP_PROGMEM if you're sending in a pointer to an array in program memory rather than a normal array 
     - OP_HOLDBACK if you want to delay sending the message and write more into the buffer */
-uint8_t tcp_send(Socket *socket, uint16_t message_len, const char *message, uint8_t operands) {
-    uart_write_P(PSTR("TCP send.\r\n"));
-    
-    uint32_t tx_free_addr = S_TX_FSR | SOCKETMASK(socket->sockno);
-    uint32_t tx_addr = S_TX_BUF | SOCKETMASK(socket->sockno);
-
+uint8_t tcp_send(uint16_t message_len, const char *message, uint8_t operands) {
     // Check space left in the buffer (shouldn't run out but you never know)
-    uint16_t send_amount = get_2_byte(tx_free_addr);
+    set_address(S_TX_FSR);
+    embed_socket(1);
+    uint16_t send_amount = get_2_byte();
     if (send_amount < message_len) {
         return 1;
     }
   
     // Start writing from the place you left off
-    tx_addr = EMBEDADDRESS(tx_addr, socket->tx_pointer);
+    set_address((TCP_Socket.tx_pointer >> 8), TCP_Socket.tx_pointer, S_TX_BUF_BLOCK);
+    embed_socket(1);
     
     // Write message to buffer
     if (operands & OP_PROGMEM) {
-        write_P(tx_addr, message_len, message);
+        write_P(message_len, message);
     } else {
-        write(tx_addr, message_len, message);
+        write(message_len, message);
     }
 
     // Increment write pointer
-    socket->tx_pointer += message_len;
+    TCP_Socket.tx_pointer += message_len;
 
     // Don't send the message yet if HOLDBACK is active
     if (operands & OP_HOLDBACK) {
         return 0;
     }
 
-    socket_send_message(socket);
+    socket_send_message(&TCP_Socket);
 
     return 0;
 }
@@ -94,43 +91,34 @@ uint8_t tcp_send(Socket *socket, uint16_t message_len, const char *message, uint
 /*  Reads the socket's RX buffer into a given buffer
     - As the only goal for our server is to get the path from a message, the message is 
     marked as entirely received even when only a small amount is in fact read */
-void tcp_read_received(const Socket *socket, uint8_t *buffer, uint8_t buffer_len) {
-    uart_write_P(PSTR("TCP read received.\r\n"));
-
-    uint32_t rx_length_addr = S_RX_RSR | SOCKETMASK(socket->sockno);
-    uint32_t rx_pointer_addr = S_RX_RD | SOCKETMASK(socket->sockno);
-    uint32_t rx_addr = S_RX_BUF | SOCKETMASK(socket->sockno);
-    uint32_t recv_addr = S_CR | SOCKETMASK(socket->sockno);
-
+void tcp_read_received(uint8_t *buffer, uint8_t buffer_len) {
     // Check how much has come in and where you left off reading
-    uint16_t received_amount = get_2_byte(rx_length_addr);
-    uint16_t rx_pointer = get_2_byte(rx_pointer_addr);
-    rx_addr = EMBEDADDRESS(rx_addr, rx_pointer);
+    set_address(S_RX_RSR);
+    embed_socket(1);
+    uint16_t received_amount = get_2_byte();
+    set_half_address(S_RX_RD_B);
+    uint16_t rx_pointer = get_2_byte();
 
     uint16_t read_amount = MIN(buffer_len, received_amount);
 
     // Read incoming into the buffer
-    read(rx_addr, buffer, buffer_len, read_amount);
+    set_address((rx_pointer >> 8), rx_pointer, S_RX_BUF_BLOCK);
+    read(buffer, buffer_len, read_amount);
 
-    // Update read pointer to mark everything as read
-    uint8_t new_rx_pointer[] = {(received_amount + rx_pointer) >> 8, (received_amount + rx_pointer)};
-    write(rx_pointer_addr, sizeof(new_rx_pointer), new_rx_pointer);
-    uint8_t recv = RECV;
-    write(recv_addr, 1, &recv);
+    // Update the read pointer
+    socket_update_read_pointer(&TCP_Socket, rx_pointer);
 }
 
 /* Sends a disconnect command to the socket, which will start a connection close process. */
-void tcp_disconnect(const Socket *socket) {    
-    uart_write_P(PSTR("TCP disconnect.\r\n"));
-    uint32_t com_addr = S_CR | SOCKETMASK(socket->sockno);
-
+void tcp_disconnect() {    
+    set_address(S_CR);
+    embed_socket(1);
+    
     uint8_t discon = DISCON;
-    write(com_addr, 1, &discon);
+    write(1, &discon);
 }
 
 /* Closes the socket. */
-void tcp_close(const Socket *socket) {
-    uart_write_P(PSTR("TCP close.\r\n"));
-    
-    socket_close(socket);
+void tcp_close() {
+    socket_close(&TCP_Socket);
 }

--- a/src/w5500.c
+++ b/src/w5500.c
@@ -8,41 +8,40 @@
 // The module provides a single W5500 instance to the user
 W5500 Wizchip;
 
-/* Device initialization */ 
-void setup_wizchip(void) {  
+/* Device initialization */
+void setup_wizchip(void) {
     Wizchip.interrupt_list_index = 0;
 
-    ASSIGN(DHCP.our_ip, 0, 0, 0, 0, 0);
-    ASSIGN(DHCP.server, 0, 0, 0, 0, 0);
-    ASSIGN(DHCP.submask, 0, 0, 0, 0, 0);
+    DHCP_Socket.sockno = 0;
+    Wizchip.sockets[0] = &DHCP_Socket;
+    dhcp_setup();
 
-    for (int i = 0; i < SOCKETNO; i++) {
-        Wizchip.sockets[i].sockno = i;
-    }
+    TCP_Socket.sockno = 1;
+    Wizchip.sockets[1] = &TCP_Socket;
 
-    // Set up the link as a 100M autonegotiated connection
+    // Set up the link as a 10M half-duplex connection
     // Feed in the new config and "use these bits for configuration" setting
-    uint8_t command = _BV(OPMD) | (PHY_ALLAN << OPMDC);
-    write(PHYCFGR, 1, &command);
+    set_address(PHYCFGR);
+    uint8_t command = _BV(OPMD) | (PHY_HD10BTNN << OPMDC);
+    write(1, &command);
     // Apply config
     command = _BV(RST);
-    write(PHYCFGR, 1, &command);
+    write(1, &command);
 
     // Clears the socket interrupt mask on the W5500
+    set_half_address(SIMR_B);
     command = 0;
-    write(SIMR, 1, &command);
-
-    
-    set_network();
-
-    // Send the first DHCP discover
-    assemble_macraw_frame(&Wizchip.sockets[DHCP_SOCKET]);
+    write(1, &command);
 
     // Enable interrupts on the microcontroller
     setup_atthing_interrupts();
+
+    #ifdef DEBUG
+        uart_write_P(PSTR("Setup complete.\r\n"));
+    #endif
 }
 
-/* Setting of various registers needed for INT0 interrupts */ 
+/* Setting of various registers needed for INT0 interrupts */
 void setup_atthing_interrupts(void) {
     cli();
 
@@ -50,17 +49,20 @@ void setup_atthing_interrupts(void) {
     INT_MODE = (INT_MODE & ~(_BV(ISC00) | _BV(ISC01)));
     // Enable INT0
     INT_ENABLE |= _BV(INT0);
+
     // Enable interrupts in general in the status register
     sei();
 }
 
 ISR(INT0_vect) {
-    uint32_t general_interrupt_addr = SIR;
-    uint32_t socket_interrupt_addr = S_IR;
+    // Take note of the original address
+    uint8_t old_pointer[] = {wizchip_address[0], wizchip_address[1], wizchip_address[2]};
+
     uint8_t sockets = 0, interrupts = 0;
 
     // Fetch interrupt register to check which socket is alerting
-    read(general_interrupt_addr, &sockets, 1, SIR_LEN);
+    set_address(SIR);
+    read(&sockets, 1, 1);
     // Test for each socket
     for (uint8_t i = 0; i < SOCKETNO; i++) {
         if (EXTRACTBIT(sockets, i) == 0) {
@@ -69,21 +71,22 @@ ISR(INT0_vect) {
 
         // Get the socket's interrupt register to see what's going on
         interrupts = 0;
-        socket_interrupt_addr = EMBEDSOCKET(socket_interrupt_addr, i);
-        read(socket_interrupt_addr, &interrupts, 1, S_IR_LEN);
-
-        // TCP sockets' tx buffer pointers are initialized on connection, so an update is necessary
-        if (Wizchip.sockets[i].mode == TCP_MODE && (interrupts & CON_INT)) {
-            uint32_t read_pointer_addr = S_TX_RD | SOCKETMASK(i);
-            Wizchip.sockets[i].tx_pointer = get_2_byte(read_pointer_addr);
-        }
+        set_address(S_IR);
+        embed_socket(i);
+        read(&interrupts, 1, 1);
 
         // Write 1s to the interrupts to clear them
-        write(socket_interrupt_addr, 1, &interrupts);
+        write(1, &interrupts);
 
-        // The interrupt mask is used to set which interrupts are active, 
+        // TCP sockets' tx buffer pointers are initialized on connection, so an update is necessary
+        if (Wizchip.sockets[i]->mode == TCP_MODE && (interrupts & CON_INT)) {
+            set_half_address(S_TX_RD_B);
+            Wizchip.sockets[i]->tx_pointer = get_2_byte();
+        }
+
+        // The interrupt mask is used to set which interrupts are active,
         // so the mask can be used to filter out any extras that shouldn't cause an alert
-        interrupts &= Wizchip.sockets[i].interrupts;
+        interrupts &= Wizchip.sockets[i]->interrupts;
 
         // If there's an interrupt, add it to the list
         if (interrupts == 0) {
@@ -99,6 +102,8 @@ ISR(INT0_vect) {
         Wizchip.interrupt_list[Wizchip.interrupt_list_index] = (i << 5) | interrupts;
         Wizchip.interrupt_list_index++;
     }
+
+    set_address(old_pointer[0], old_pointer[1], old_pointer[2]);
 }
 
 


### PR DESCRIPTION
- Switched to 3-byte addresses with global allocation for Wizchip communication and overhauled everything address-related.
- Switched to set sockets for TCP and DHCP. 
- Whitespace removals.

- Readme now outdated, should be updated.